### PR TITLE
Refine portfolio landing page styling

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -1,0 +1,847 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@600;700&display=swap');
+
+:root {
+  --accent: #2d7bff;
+  --accent-alt: #6c63ff;
+  --bg-light: #f7f9fc;
+  --bg-dark: #05060f;
+  --card-light: rgba(255, 255, 255, 0.85);
+  --card-dark: rgba(13, 17, 23, 0.85);
+  --text-light: #111826;
+  --text-dark: #f6f7fb;
+  --transition: 0.35s ease;
+  --radius-lg: 28px;
+  --radius-md: 20px;
+  --shadow-lg: 0 32px 70px rgba(15, 23, 42, 0.25);
+  --shadow-md: 0 22px 50px rgba(15, 23, 42, 0.12);
+  --max-width: 1140px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.65;
+  background: var(--bg-light);
+  color: var(--text-light);
+  overflow-x: hidden;
+  transition: background var(--transition), color var(--transition);
+}
+
+body::before,
+body::after {
+  content: '';
+  position: fixed;
+  top: -200px;
+  left: -150px;
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(circle at center, rgba(109, 76, 255, 0.4), transparent 60%);
+  z-index: -2;
+  filter: blur(0px);
+  transform: rotate(15deg);
+  animation: pulse 8s ease-in-out infinite alternate;
+}
+
+body::after {
+  top: auto;
+  bottom: -220px;
+  left: auto;
+  right: -160px;
+  background: radial-gradient(circle at center, rgba(45, 123, 255, 0.45), transparent 65%);
+  animation-delay: 2s;
+}
+
+@keyframes pulse {
+  from {
+    transform: scale(1) rotate(15deg);
+    opacity: 0.65;
+  }
+  to {
+    transform: scale(1.15) rotate(20deg);
+    opacity: 0.9;
+  }
+}
+
+body.dark {
+  background: radial-gradient(circle at 15% 15%, rgba(45, 123, 255, 0.1), transparent 55%),
+              radial-gradient(circle at 80% 10%, rgba(96, 76, 255, 0.12), transparent 60%),
+              var(--bg-dark);
+  color: var(--text-dark);
+}
+
+body.dark::before {
+  background: radial-gradient(circle at center, rgba(45, 123, 255, 0.32), transparent 60%);
+}
+
+body.dark::after {
+  background: radial-gradient(circle at center, rgba(108, 99, 255, 0.28), transparent 60%);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+li {
+  list-style: none;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+section {
+  width: min(92%, var(--max-width));
+  margin: 0 auto 6.5rem;
+  position: relative;
+}
+
+section .section-shell {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.55));
+  border-radius: var(--radius-lg);
+  padding: clamp(3rem, 5vw, 4.5rem);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(18px);
+  position: relative;
+  overflow: hidden;
+}
+
+body.dark section .section-shell {
+  background: linear-gradient(135deg, rgba(22, 27, 34, 0.95), rgba(13, 17, 23, 0.75));
+  box-shadow: 0 22px 55px rgba(3, 10, 25, 0.6);
+}
+
+section .section-shell::after {
+  content: '';
+  position: absolute;
+  inset: 18px;
+  border-radius: calc(var(--radius-lg) - 16px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+body.dark section .section-shell::after {
+  border-color: rgba(88, 166, 255, 0.18);
+}
+
+.section__title {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.2rem, 4vw, 2.9rem);
+  text-align: center;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(120deg, var(--accent), var(--accent-alt));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.section__subtitle {
+  text-align: center;
+  font-size: 1.05rem;
+  color: rgba(17, 24, 38, 0.65);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 2.8rem;
+}
+
+body.dark .section__subtitle {
+  color: rgba(246, 247, 251, 0.65);
+}
+
+/* Header */
+.header {
+  position: fixed;
+  inset: 0 0 auto 0;
+  z-index: 1000;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(22px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  transition: var(--transition);
+}
+
+body.dark .header {
+  background: rgba(13, 17, 23, 0.92);
+  border-bottom-color: rgba(88, 166, 255, 0.12);
+}
+
+.header.scrolled {
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+}
+
+body.dark .header.scrolled {
+  background: rgba(10, 13, 19, 0.95);
+  box-shadow: 0 28px 55px rgba(3, 10, 25, 0.6);
+}
+
+.nav.container {
+  width: min(92%, var(--max-width));
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.1rem 0;
+}
+
+.nav__logo {
+  font-weight: 700;
+  font-size: 1.35rem;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+}
+
+body.dark .nav__logo {
+  color: #8fb7ff;
+}
+
+.nav__menu {
+  position: fixed;
+  top: 80px;
+  right: 24px;
+  padding: 1.6rem 1.8rem;
+  background: rgba(255, 255, 255, 0.97);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  transform-origin: top right;
+  transform: scale(0.7);
+  opacity: 0;
+  visibility: hidden;
+  transition: var(--transition);
+}
+
+body.dark .nav__menu {
+  background: rgba(13, 17, 23, 0.98);
+}
+
+.nav__menu.show {
+  transform: scale(1);
+  opacity: 1;
+  visibility: visible;
+}
+
+.nav__list {
+  display: grid;
+  gap: 1rem;
+}
+
+.nav__link {
+  font-weight: 500;
+  color: rgba(17, 24, 38, 0.75);
+  padding: 0.4rem 0.6rem;
+  border-radius: 12px;
+  transition: var(--transition);
+}
+
+body.dark .nav__link {
+  color: rgba(246, 247, 251, 0.75);
+}
+
+.nav__link:hover,
+.nav__link.active {
+  color: var(--accent);
+  background: rgba(45, 123, 255, 0.08);
+}
+
+body.dark .nav__link:hover,
+body.dark .nav__link.active {
+  color: #9dc4ff;
+  background: rgba(88, 166, 255, 0.12);
+}
+
+.nav__btns {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.nav__btns button {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  border: none;
+  background: rgba(45, 123, 255, 0.12);
+  color: var(--accent);
+  cursor: pointer;
+  transition: var(--transition);
+  font-size: 1.25rem;
+}
+
+.nav__btns button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(45, 123, 255, 0.22);
+}
+
+body.dark .nav__btns button {
+  background: rgba(88, 166, 255, 0.18);
+  color: #b3d6ff;
+}
+
+.nav__toggle {
+  font-size: 1.4rem;
+}
+
+@media (min-width: 880px) {
+  .nav__menu {
+    position: static;
+    transform: none;
+    opacity: 1;
+    visibility: visible;
+    background: transparent;
+    padding: 0;
+    box-shadow: none;
+  }
+
+  .nav__list {
+    display: flex;
+    gap: 1.8rem;
+    align-items: center;
+  }
+
+  .nav__link {
+    background: transparent;
+  }
+
+  .nav__toggle {
+    display: none;
+  }
+}
+
+/* Hero */
+.home {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding-top: 7.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.home__content {
+  position: relative;
+  z-index: 1;
+  width: min(92%, 760px);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.6rem;
+  justify-items: center;
+}
+
+.home__img {
+  position: relative;
+}
+
+.home__img::before {
+  content: '';
+  position: absolute;
+  inset: -20px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(45, 123, 255, 0.35), rgba(108, 99, 255, 0.45));
+  filter: blur(0px);
+  z-index: 0;
+  animation: glow 6s ease-in-out infinite;
+}
+
+.home__img img {
+  width: min(240px, 55vw);
+  border-radius: 50%;
+  border: 6px solid rgba(255, 255, 255, 0.75);
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.35);
+  position: relative;
+  z-index: 1;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+body.dark .home__img img {
+  border-color: rgba(88, 166, 255, 0.6);
+}
+
+.home__img img:hover {
+  transform: translateY(-6px) scale(1.02);
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.3);
+}
+
+@keyframes glow {
+  from {
+    transform: scale(1);
+    opacity: 0.75;
+  }
+  to {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+}
+
+.home__title {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.6rem, 5vw, 3.4rem);
+  color: var(--text-light);
+}
+
+body.dark .home__title {
+  color: var(--text-dark);
+}
+
+.home__title span {
+  background: linear-gradient(120deg, var(--accent), var(--accent-alt));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.home__subtitle {
+  font-size: clamp(1.1rem, 2.5vw, 1.4rem);
+  font-weight: 500;
+  color: rgba(17, 24, 38, 0.65);
+}
+
+body.dark .home__subtitle {
+  color: rgba(246, 247, 251, 0.65);
+}
+
+.home__description {
+  max-width: 520px;
+  color: rgba(17, 24, 38, 0.75);
+  font-size: 1.05rem;
+}
+
+body.dark .home__description {
+  color: rgba(246, 247, 251, 0.75);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: linear-gradient(120deg, var(--accent), var(--accent-alt));
+  color: #fff;
+  padding: 0.85rem 1.85rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: 0 18px 30px rgba(45, 123, 255, 0.25);
+  transition: var(--transition);
+}
+
+.button:hover {
+  transform: translateY(-3px) scale(1.03);
+  box-shadow: 0 24px 45px rgba(45, 123, 255, 0.32);
+}
+
+.button--success {
+  background: linear-gradient(120deg, #35d399, #07b981);
+  box-shadow: 0 18px 36px rgba(7, 185, 129, 0.28);
+  color: #fff;
+}
+
+/* About */
+.about .section-shell {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+  align-items: center;
+}
+
+.about__container {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3.5rem);
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.about__img {
+  border-radius: 30px;
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  position: relative;
+}
+
+.about__img img {
+  width: 100%;
+  transition: transform var(--transition);
+}
+
+.about__img::after {
+  content: '';
+  position: absolute;
+  inset: 18px;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+body.dark .about__img::after {
+  border-color: rgba(88, 166, 255, 0.2);
+}
+
+.about__img:hover img {
+  transform: scale(1.05);
+}
+
+.about__data p {
+  margin-bottom: 1.2rem;
+  color: rgba(17, 24, 38, 0.78);
+  font-size: 1.02rem;
+}
+
+body.dark .about__data p {
+  color: rgba(246, 247, 251, 0.78);
+}
+
+.about__data ul {
+  display: grid;
+  gap: 0.6rem;
+  color: rgba(17, 24, 38, 0.75);
+  font-weight: 500;
+}
+
+body.dark .about__data ul {
+  color: rgba(246, 247, 251, 0.75);
+}
+
+.about__data .button {
+  margin-top: 0.5rem;
+}
+
+/* Services */
+.services__container {
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.services__content {
+  padding: 2.2rem 1.9rem;
+  border-radius: 24px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.9), rgba(240, 244, 255, 0.7));
+  box-shadow: var(--shadow-md);
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  transform: translateY(0);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.services__content::after {
+  content: '';
+  position: absolute;
+  inset: 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(45, 123, 255, 0.18);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+body.dark .services__content {
+  background: linear-gradient(145deg, rgba(20, 26, 35, 0.95), rgba(13, 17, 23, 0.82));
+  box-shadow: 0 22px 45px rgba(3, 10, 25, 0.55);
+}
+
+.services__content:hover {
+  transform: translateY(-12px);
+  box-shadow: 0 26px 55px rgba(45, 123, 255, 0.22);
+}
+
+.services__icon {
+  font-size: 2.6rem;
+  color: var(--accent);
+  margin-bottom: 1.1rem;
+}
+
+body.dark .services__icon {
+  color: #9fc5ff;
+}
+
+.services__content h3 {
+  font-size: 1.3rem;
+  margin-bottom: 0.75rem;
+}
+
+.services__content p {
+  color: rgba(17, 24, 38, 0.68);
+}
+
+body.dark .services__content p {
+  color: rgba(246, 247, 251, 0.7);
+}
+
+/* Qualification */
+.qualification__timeline {
+  position: relative;
+  margin-top: 2.5rem;
+  padding-left: clamp(1rem, 4vw, 2.8rem);
+}
+
+.qualification__timeline::before {
+  content: '';
+  position: absolute;
+  left: clamp(0.5rem, 3vw, 1.2rem);
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(45, 123, 255, 0.5), transparent);
+}
+
+.qualification__item {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(244, 248, 255, 0.75));
+  border-radius: 22px;
+  padding: 1.6rem 1.8rem;
+  margin-bottom: 1.8rem;
+  position: relative;
+  box-shadow: var(--shadow-md);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+body.dark .qualification__item {
+  background: linear-gradient(145deg, rgba(20, 26, 35, 0.92), rgba(13, 17, 23, 0.82));
+  box-shadow: 0 22px 45px rgba(3, 10, 25, 0.55);
+}
+
+.qualification__item::before {
+  content: '';
+  position: absolute;
+  left: calc(-1 * clamp(1.4rem, 4vw, 2.2rem));
+  top: 1.6rem;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(120deg, var(--accent), var(--accent-alt));
+  box-shadow: 0 0 0 4px rgba(45, 123, 255, 0.15);
+}
+
+.qualification__item:hover {
+  transform: translateX(10px);
+  box-shadow: 0 26px 55px rgba(45, 123, 255, 0.2);
+}
+
+.qualification__item h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.4rem;
+}
+
+.qualification__item span {
+  color: rgba(17, 24, 38, 0.6);
+}
+
+body.dark .qualification__item span {
+  color: rgba(246, 247, 251, 0.6);
+}
+
+/* Contact */
+.contact__form {
+  display: grid;
+  gap: 1.3rem;
+  max-width: min(640px, 100%);
+  margin: 0 auto;
+  padding: 2.4rem 2.7rem;
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.9), rgba(240, 244, 255, 0.7));
+  box-shadow: var(--shadow-md);
+  position: relative;
+  overflow: hidden;
+}
+
+body.dark .contact__form {
+  background: linear-gradient(145deg, rgba(20, 26, 35, 0.95), rgba(13, 17, 23, 0.82));
+  box-shadow: 0 26px 55px rgba(3, 10, 25, 0.55);
+}
+
+.contact__form::after {
+  content: '';
+  position: absolute;
+  inset: 16px;
+  border-radius: 24px;
+  border: 1px solid rgba(45, 123, 255, 0.2);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.contact__form.sent {
+  box-shadow: 0 28px 60px rgba(7, 185, 129, 0.25);
+}
+
+.contact__form.sent::after {
+  border-color: rgba(53, 211, 153, 0.35);
+}
+
+.contact__input,
+.contact__textarea {
+  border-radius: 18px;
+  border: 1px solid rgba(45, 123, 255, 0.18);
+  padding: 0.95rem 1.1rem;
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 1rem;
+  color: rgba(17, 24, 38, 0.78);
+  transition: var(--transition);
+  backdrop-filter: blur(4px);
+}
+
+.contact__textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.contact__input:focus,
+.contact__textarea:focus {
+  outline: none;
+  border-color: rgba(45, 123, 255, 0.45);
+  box-shadow: 0 0 0 4px rgba(45, 123, 255, 0.12);
+}
+
+body.dark .contact__input,
+body.dark .contact__textarea {
+  background: rgba(17, 23, 32, 0.7);
+  color: rgba(246, 247, 251, 0.85);
+  border-color: rgba(88, 166, 255, 0.25);
+}
+
+body.dark .contact__input:focus,
+body.dark .contact__textarea:focus {
+  border-color: rgba(88, 166, 255, 0.5);
+  box-shadow: 0 0 0 4px rgba(88, 166, 255, 0.12);
+}
+
+/* Footer */
+.footer {
+  width: min(92%, var(--max-width));
+  margin: 0 auto 4rem;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.88), rgba(240, 244, 255, 0.72));
+  border-radius: 28px;
+  padding: 3rem 2rem;
+  text-align: center;
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(12px);
+}
+
+body.dark .footer {
+  background: linear-gradient(145deg, rgba(20, 26, 35, 0.94), rgba(13, 17, 23, 0.85));
+  box-shadow: 0 24px 50px rgba(3, 10, 25, 0.55);
+}
+
+.footer__title {
+  font-family: 'Playfair Display', serif;
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.footer__subtitle {
+  color: rgba(17, 24, 38, 0.6);
+  font-weight: 500;
+}
+
+body.dark .footer__subtitle {
+  color: rgba(246, 247, 251, 0.6);
+}
+
+.footer__socials {
+  margin: 1.8rem 0;
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.footer__socials a {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(45, 123, 255, 0.12);
+  color: var(--accent);
+  font-size: 1.5rem;
+  transition: var(--transition);
+}
+
+.footer__socials a:hover {
+  transform: translateY(-4px) scale(1.05);
+  box-shadow: 0 18px 30px rgba(45, 123, 255, 0.24);
+}
+
+body.dark .footer__socials a {
+  background: rgba(88, 166, 255, 0.18);
+  color: #a7ceff;
+}
+
+.footer__copy {
+  color: rgba(17, 24, 38, 0.5);
+  font-size: 0.95rem;
+}
+
+body.dark .footer__copy {
+  color: rgba(246, 247, 251, 0.55);
+}
+
+/* Scroll reveal */
+.reveal {
+  opacity: 0;
+  transform: translateY(48px) scale(0.98);
+  transition: opacity 0.9s ease, transform 0.9s ease;
+}
+
+.reveal.active {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+/* Particle canvas */
+#particle-canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  opacity: 0.8;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(var(--accent), var(--accent-alt));
+  border-radius: 999px;
+}
+
+/* Responsive tweaks */
+@media (max-width: 680px) {
+  .nav__btns button {
+    width: 40px;
+    height: 40px;
+  }
+
+  .home__description {
+    font-size: 1rem;
+  }
+
+  section .section-shell {
+    padding: 2.6rem clamp(1.4rem, 5vw, 2rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -1,0 +1,204 @@
+const navMenu = document.getElementById('nav-menu');
+const navToggle = document.getElementById('nav-toggle');
+const themeToggle = document.getElementById('theme-toggle');
+const header = document.querySelector('.header');
+const navLinks = document.querySelectorAll('.nav__link');
+const revealItems = document.querySelectorAll('.reveal, section .section-shell');
+const contactForm = document.querySelector('.contact__form');
+
+// Mobile Menu toggle
+if (navToggle && navMenu) {
+  navToggle.addEventListener('click', () => {
+    navMenu.classList.toggle('show');
+    navToggle.setAttribute('aria-expanded', navMenu.classList.contains('show'));
+  });
+
+  navLinks.forEach((link) =>
+    link.addEventListener('click', () => {
+      navMenu.classList.remove('show');
+      navToggle.setAttribute('aria-expanded', 'false');
+    })
+  );
+}
+
+// Theme Toggle with persistence
+const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+const storedTheme = localStorage.getItem('avi-theme');
+
+const applyTheme = (theme) => {
+  const body = document.body;
+  if (theme === 'dark') {
+    body.classList.add('dark');
+    body.classList.remove('light');
+    themeToggle.innerHTML = '<i class="uil uil-sun"></i>';
+  } else {
+    body.classList.add('light');
+    body.classList.remove('dark');
+    themeToggle.innerHTML = '<i class="uil uil-moon"></i>';
+  }
+};
+
+applyTheme(storedTheme || (prefersDarkScheme.matches ? 'dark' : 'light'));
+
+themeToggle.addEventListener('click', () => {
+  const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+  applyTheme(newTheme);
+  localStorage.setItem('avi-theme', newTheme);
+});
+
+prefersDarkScheme.addEventListener('change', (event) => {
+  if (!localStorage.getItem('avi-theme')) {
+    applyTheme(event.matches ? 'dark' : 'light');
+  }
+});
+
+// Scroll reveal using IntersectionObserver
+const observer = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('active');
+        observer.unobserve(entry.target);
+      }
+    });
+  },
+  {
+    threshold: 0.15,
+    rootMargin: '0px 0px -80px 0px',
+  }
+);
+
+revealItems.forEach((item) => observer.observe(item));
+
+// Header state on scroll
+const handleScroll = () => {
+  if (window.scrollY > 24) {
+    header.classList.add('scrolled');
+  } else {
+    header.classList.remove('scrolled');
+  }
+};
+
+window.addEventListener('scroll', handleScroll);
+handleScroll();
+
+// Active link tracking
+const sectionElements = document.querySelectorAll('section[id]');
+const navObserver = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      const id = entry.target.getAttribute('id');
+      const activeLink = document.querySelector(`.nav__link[href="#${id}"]`);
+      if (entry.isIntersecting) {
+        navLinks.forEach((link) => link.classList.remove('active'));
+        if (activeLink) {
+          activeLink.classList.add('active');
+        }
+      }
+    });
+  },
+  {
+    threshold: 0.6,
+  }
+);
+
+sectionElements.forEach((section) => navObserver.observe(section));
+
+// Contact form feedback (non-submitting for demo)
+if (contactForm) {
+  contactForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    contactForm.classList.add('sent');
+    const button = contactForm.querySelector('button');
+    button.classList.add('button--success');
+    setTimeout(() => {
+      button.classList.remove('button--success');
+      contactForm.reset();
+      contactForm.classList.remove('sent');
+    }, 2000);
+  });
+}
+
+// Particle background enhancement for retina devices
+const canvas = document.getElementById('particle-canvas');
+if (canvas) {
+  const ctx = canvas.getContext('2d');
+  const particlesArray = [];
+  const particleCount = 140;
+
+  const resizeCanvas = () => {
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = window.innerWidth * ratio;
+    canvas.height = window.innerHeight * ratio;
+    canvas.style.width = `${window.innerWidth}px`;
+    canvas.style.height = `${window.innerHeight}px`;
+    ctx.scale(ratio, ratio);
+  };
+
+  resizeCanvas();
+
+  window.addEventListener('resize', () => {
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    resizeCanvas();
+  });
+
+  class Particle {
+    constructor() {
+      this.reset();
+    }
+
+    reset() {
+      this.x = Math.random() * window.innerWidth;
+      this.y = Math.random() * window.innerHeight;
+      this.radius = Math.random() * 2 + 1;
+      this.dx = (Math.random() - 0.5) * 0.7;
+      this.dy = (Math.random() - 0.5) * 0.7;
+    }
+
+    draw() {
+      ctx.beginPath();
+      ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+      ctx.fillStyle = 'rgba(45, 123, 255, 0.75)';
+      ctx.fill();
+    }
+
+    update() {
+      if (this.x > window.innerWidth || this.x < 0) this.dx *= -1;
+      if (this.y > window.innerHeight || this.y < 0) this.dy *= -1;
+      this.x += this.dx;
+      this.y += this.dy;
+      this.draw();
+    }
+  }
+
+  for (let i = 0; i < particleCount; i += 1) {
+    particlesArray.push(new Particle());
+  }
+
+  const connectParticles = () => {
+    for (let a = 0; a < particlesArray.length; a += 1) {
+      for (let b = a + 1; b < particlesArray.length; b += 1) {
+        const dx = particlesArray[a].x - particlesArray[b].x;
+        const dy = particlesArray[a].y - particlesArray[b].y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        if (distance < 110) {
+          ctx.beginPath();
+          ctx.strokeStyle = 'rgba(45, 123, 255, 0.08)';
+          ctx.lineWidth = 1;
+          ctx.moveTo(particlesArray[a].x, particlesArray[a].y);
+          ctx.lineTo(particlesArray[b].x, particlesArray[b].y);
+          ctx.stroke();
+        }
+      }
+    }
+  };
+
+  const animate = () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    particlesArray.forEach((particle) => particle.update());
+    connectParticles();
+    requestAnimationFrame(animate);
+  };
+
+  animate();
+}

--- a/index.html
+++ b/index.html
@@ -8,99 +8,7 @@
   <!-- Icons -->
   <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.8/css/line.css">
   <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
-
-  <style>
-    /* ==== RESET ==== */
-    * { margin:0; padding:0; box-sizing:border-box; }
-    body { font-family:'Poppins', sans-serif; line-height:1.6; overflow-x:hidden; transition:all 0.4s ease; }
-    a { text-decoration:none; }
-    li { list-style:none; }
-
-    /* ==== THEME ==== */
-    body.light { --bg:#f8f9fa; --text:#222; --card:#fff; --accent:#0077ff; }
-    body.dark { --bg:#0d1117; --text:#eaeaea; --card:#161b22; --accent:#58a6ff; }
-    body { background:var(--bg); color:var(--text); }
-
-    /* ==== HEADER ==== */
-    .header { position:fixed; top:0; left:0; right:0; background:var(--card); backdrop-filter:blur(10px); box-shadow:0 2px 10px rgba(0,0,0,0.2); z-index:1000; }
-    .nav.container { display:flex; justify-content:space-between; align-items:center; padding:1rem 2rem; max-width:1200px; margin:auto; }
-    .nav__logo { font-size:1.3rem; font-weight:700; color:var(--accent); }
-    .nav__menu { display:none; }
-    .nav__menu.show { display:block; position:absolute; top:60px; right:1rem; background:var(--card); padding:1rem; border-radius:12px; box-shadow:0 2px 10px rgba(0,0,0,0.2);}
-    .nav__list { display:grid; gap:0.8rem; }
-    .nav__link { color: var(--text); font-weight:500; transition:0.3s; }
-    .nav__link:hover { color: var(--accent); }
-    .nav__btns button { background:none; border:none; cursor:pointer; font-size:1.4rem; color:var(--accent); margin-left:.5rem; }
-    .nav__toggle { cursor:pointer; }
-    @media(min-width:768px){ .nav__menu{display:block !important; position:static; background:none; box-shadow:none;} .nav__list{display:flex; gap:2rem;} .nav__toggle{display:none;} }
-
-    /* ==== HERO ==== */
-    .home { min-height:100vh; display:flex; flex-direction:column; justify-content:center; align-items:center; text-align:center; position:relative; overflow:hidden; padding:2rem 1rem; }
-    #particle-canvas { position:absolute; top:0; left:0; width:100%; height:100%; z-index:0; }
-    .home__content { position:relative; z-index:1; }
-    .home__img img { border-radius:50%; width:180px; border:4px solid var(--accent); box-shadow:0 0 20px rgba(0,0,0,0.3); transition:0.5s; }
-    .home__img img:hover { transform:scale(1.05) rotate(3deg); }
-    .home__title { font-size:2.5rem; margin:1rem 0 .5rem; }
-    .home__title span { color:var(--accent); }
-    .home__subtitle { font-size:1.2rem; color:gray; margin-bottom:1rem; }
-    .home__description { max-width:600px; margin:auto; }
-    .button { background:var(--accent); color:#fff; padding:.8rem 1.5rem; border-radius:50px; display:inline-flex; align-items:center; gap:.5rem; transition:0.3s; }
-    .button:hover { transform:scale(1.05); box-shadow:0 8px 20px rgba(0,0,0,0.2); }
-
-    /* ==== SECTIONS STYLISH ==== */
-    section { padding:6rem 1rem; max-width:1100px; margin:auto; position:relative; border-radius:20px; }
-    section::before { content:''; position:absolute; top:0; left:0; right:0; bottom:0; background: rgba(255,255,255,0.05); backdrop-filter: blur(15px); border-radius:20px; z-index:0; }
-    section > * { position: relative; z-index:1; }
-    .section__title { font-size:2.5rem; text-align:center; margin-bottom:1rem; background: linear-gradient(90deg,var(--accent), #00d4ff); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
-    .section__subtitle { text-align:center; margin-bottom:3rem; color: gray; font-weight:500; }
-
-    /* ABOUT */
-    .about__container { display:grid; gap:3rem; align-items:center; }
-/* ABOUT IMAGE FIX */
-.about__img {
-  width: 100%;
-  max-width: 350px;   /* sets a maximum size */
-  height: auto;       /* maintains aspect ratio */
-  border-radius: 30px;
-  box-shadow: 0 20px 50px rgba(0,0,0,0.2);
-  transition: transform 0.4s;
-  justify-self: center; /* centers the image in the grid */
-}
-@media (max-width:768px){
-  .about__container { grid-template-columns: 1fr; gap:2rem; }
-  .about__img { max-width: 250px; }
-}
-
-    .about__img:hover { transform: scale(1.05) rotate(2deg); }
-    .about__data p { margin-bottom:1rem; line-height:1.7; }
-
-    /* SERVICES */
-    .services__container { display:grid; gap:2rem; }
-    .services__content { background: rgba(255,255,255,0.05); backdrop-filter: blur(15px); padding:2rem; border-radius:20px; text-align:center; transition:0.5s; box-shadow: 0 10px 30px rgba(0,0,0,0.15); }
-    .services__content:hover { transform: translateY(-10px) scale(1.05); box-shadow: 0 20px 40px rgba(0,0,0,0.25); }
-    .services__icon { font-size:3rem; color:var(--accent); margin-bottom:1rem; }
-    @media(min-width:768px){ .services__container{grid-template-columns:repeat(3,1fr);} }
-
-    /* QUALIFICATION */
-    .qualification__timeline { border-left: 4px solid var(--accent); padding-left: 1.5rem; margin-top:2rem; }
-    .qualification__item { margin-bottom:2rem; padding:1rem 1.5rem; background: rgba(255,255,255,0.05); backdrop-filter: blur(15px); border-radius:20px; transition: transform 0.4s, box-shadow 0.4s; }
-    .qualification__item:hover { transform: translateX(10px); box-shadow:0 15px 35px rgba(0,0,0,0.2); }
-
-    /* CONTACT */
-    .contact__form { display:grid; gap:1.5rem; max-width:600px; margin:auto; background: rgba(255,255,255,0.05); padding:2rem; border-radius:20px; backdrop-filter: blur(15px); box-shadow: 0 15px 35px rgba(0,0,0,0.2); }
-    .contact__input, .contact__textarea { border-radius:15px; border:2px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color:var(--text); padding:1rem; font-size:1rem; transition:0.3s; }
-    .contact__input:focus, .contact__textarea:focus { border-color: var(--accent); background: rgba(255,255,255,0.2); outline:none; }
-
-    /* FOOTER */
-    .footer { text-align:center; padding:3rem 1rem; background: rgba(255,255,255,0.05); backdrop-filter: blur(15px); border-radius:20px; box-shadow: 0 15px 35px rgba(0,0,0,0.2); margin-top:4rem; }
-    .footer__socials a { font-size:2rem; margin:0 .8rem; transition:0.3s; }
-    .footer__socials a:hover { transform:scale(1.3); color: var(--accent); }
-
-    /* REVEAL */
-    .reveal { opacity:0; transform:translateY(30px); transition:all .8s ease; }
-    .reveal.active { opacity:1; transform:translateY(0); }
-
-  </style>
+  <link rel="stylesheet" href="assets/css/home.css">
 </head>
 <body class="light">
 
@@ -118,8 +26,8 @@
       </ul>
     </div>
     <div class="nav__btns">
-      <button id="theme-toggle"><i class="uil uil-moon"></i></button>
-      <button class="nav__toggle" id="nav-toggle"><i class="uil uil-apps"></i></button>
+      <button id="theme-toggle" aria-label="Toggle theme"><i class="uil uil-moon"></i></button>
+      <button class="nav__toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false"><i class="uil uil-apps"></i></button>
     </div>
   </nav>
 </header>
@@ -138,58 +46,68 @@
 
 <!-- ABOUT -->
 <section class="about reveal" id="about">
-  <h2 class="section__title">About Me</h2>
-  <span class="section__subtitle">Who I Am</span>
-  <div class="about__container">
-    <img src="assets/img/009.jpg" alt="About" class="about__img">
-    <div class="about__data">
-      <p>I am seeking a dynamic opportunity to provide exceptional dental care and enhance patient experiences through innovative treatment techniques.</p>
-      <p>With extensive experience in general and cosmetic dentistry, I focus on enhancing patient health and satisfaction.</p>
-      <ul>
-        <li>✔ Expert in diagnostics & restorative practices.</li>
-        <li>✔ Committed to compassionate care & outcomes.</li>
-      </ul>
-      <a href="assets/img/avi.pdf" download class="button">Download CV <i class="uil uil-download-alt"></i></a>
+  <div class="section-shell">
+    <h2 class="section__title">About Me</h2>
+    <span class="section__subtitle">Who I Am</span>
+    <div class="about__container">
+      <div class="about__img">
+        <img src="assets/img/009.jpg" alt="About">
+      </div>
+      <div class="about__data">
+        <p>I am seeking a dynamic opportunity to provide exceptional dental care and enhance patient experiences through innovative treatment techniques.</p>
+        <p>With extensive experience in general and cosmetic dentistry, I focus on enhancing patient health and satisfaction.</p>
+        <ul>
+          <li>✔ Expert in diagnostics & restorative practices.</li>
+          <li>✔ Committed to compassionate care & outcomes.</li>
+        </ul>
+        <a href="assets/img/avi.pdf" download class="button">Download CV <i class="uil uil-download-alt"></i></a>
+      </div>
     </div>
   </div>
 </section>
 
 <!-- SERVICES -->
 <section class="services reveal" id="services">
-  <h2 class="section__title">Services</h2>
-  <span class="section__subtitle">Transforming smiles with care & innovation</span>
-  <div class="services__container">
-    <div class="services__content"><i class="fas fa-tooth services__icon"></i><h3>General Dentistry</h3><p>Check-ups, cleanings & cavity care to maintain oral health.</p></div>
-    <div class="services__content"><i class="fas fa-smile services__icon"></i><h3>Cosmetic Dentistry</h3><p>Whitening, veneers & bonding for a beautiful smile.</p></div>
-    <div class="services__content"><i class="fas fa-tools services__icon"></i><h3>Restorative Dentistry</h3><p>Crowns, fillings & bridges with natural aesthetics.</p></div>
-    <div class="services__content"><i class="fas fa-child services__icon"></i><h3>Pediatric Dentistry</h3><p>Gentle care for children fostering lifelong oral health.</p></div>
-    <div class="services__content"><i class="fas fa-ambulance services__icon"></i><h3>Emergency Care</h3><p>Quick relief for broken teeth, pain & urgent injuries.</p></div>
+  <div class="section-shell">
+    <h2 class="section__title">Services</h2>
+    <span class="section__subtitle">Transforming smiles with care & innovation</span>
+    <div class="services__container">
+      <div class="services__content"><i class="fas fa-tooth services__icon"></i><h3>General Dentistry</h3><p>Check-ups, cleanings & cavity care to maintain oral health.</p></div>
+      <div class="services__content"><i class="fas fa-smile services__icon"></i><h3>Cosmetic Dentistry</h3><p>Whitening, veneers & bonding for a beautiful smile.</p></div>
+      <div class="services__content"><i class="fas fa-tools services__icon"></i><h3>Restorative Dentistry</h3><p>Crowns, fillings & bridges with natural aesthetics.</p></div>
+      <div class="services__content"><i class="fas fa-child services__icon"></i><h3>Pediatric Dentistry</h3><p>Gentle care for children fostering lifelong oral health.</p></div>
+      <div class="services__content"><i class="fas fa-ambulance services__icon"></i><h3>Emergency Care</h3><p>Quick relief for broken teeth, pain & urgent injuries.</p></div>
+    </div>
   </div>
 </section>
 
 <!-- QUALIFICATION -->
 <section class="qualification reveal" id="qualification">
-  <h2 class="section__title">Qualification</h2>
-  <span class="section__subtitle">My personal journey</span>
-  <div class="qualification__timeline">
-    <div class="qualification__item"><h3>Upto Class 3</h3><span>Nightingale Academy, Banepa</span></div>
-    <div class="qualification__item"><h3>Upto Class 5</h3><span>Eastern Jyoti English School, Saptari</span></div>
-    <div class="qualification__item"><h3>Upto Class 10</h3><span>Mother Teresa Secondary School, Biratnagar</span></div>
-    <div class="qualification__item"><h3>Upto Class 12</h3><span>Arniko Awashiya Higher Secondary School, Biratnagar</span></div>
-    <div class="qualification__item"><h3>BDS Graduated</h3><span>B.P. Koirala Institute of Health Sciences, Dharan (2017-2024)</span></div>
+  <div class="section-shell">
+    <h2 class="section__title">Qualification</h2>
+    <span class="section__subtitle">My personal journey</span>
+    <div class="qualification__timeline">
+      <div class="qualification__item"><h3>Upto Class 3</h3><span>Nightingale Academy, Banepa</span></div>
+      <div class="qualification__item"><h3>Upto Class 5</h3><span>Eastern Jyoti English School, Saptari</span></div>
+      <div class="qualification__item"><h3>Upto Class 10</h3><span>Mother Teresa Secondary School, Biratnagar</span></div>
+      <div class="qualification__item"><h3>Upto Class 12</h3><span>Arniko Awashiya Higher Secondary School, Biratnagar</span></div>
+      <div class="qualification__item"><h3>BDS Graduated</h3><span>B.P. Koirala Institute of Health Sciences, Dharan (2017-2024)</span></div>
+    </div>
   </div>
 </section>
 
 <!-- CONTACT -->
 <section class="contact reveal" id="contact">
-  <h2 class="section__title">Contact Me</h2>
-  <span class="section__subtitle">Let’s build something amazing together</span>
-  <form class="contact__form">
-    <input type="text" class="contact__input" placeholder="Your Name" required>
-    <input type="email" class="contact__input" placeholder="Your Email" required>
-    <textarea class="contact__textarea" placeholder="Your Message" required></textarea>
-    <button type="submit" class="button">Send Message <i class="uil uil-message"></i></button>
-  </form>
+  <div class="section-shell">
+    <h2 class="section__title">Contact Me</h2>
+    <span class="section__subtitle">Let’s build something amazing together</span>
+    <form class="contact__form">
+      <input type="text" class="contact__input" placeholder="Your Name" required>
+      <input type="email" class="contact__input" placeholder="Your Email" required>
+      <textarea class="contact__textarea" placeholder="Your Message" required></textarea>
+      <button type="submit" class="button">Send Message <i class="uil uil-message"></i></button>
+    </form>
+  </div>
 </section>
 
 <!-- FOOTER -->
@@ -197,89 +115,14 @@
   <h1 class="footer__title">Avinash Yadav</h1>
   <span class="footer__subtitle">Bachelor of Dental Surgery Graduate</span>
   <div class="footer__socials">
-    <a href="https://www.instagram.com/avi_avi0727/" target="_blank"><i class="uil uil-instagram"></i></a>
-    <a href="https://www.linkedin.com/in/avinashyadav" target="_blank"><i class="uil uil-linkedin"></i></a>
-    <a href="https://github.com/avinashyadav" target="_blank"><i class="uil uil-github"></i></a>
+    <a href="https://www.instagram.com/avi_avi0727/" target="_blank" aria-label="Instagram"><i class="uil uil-instagram"></i></a>
+    <a href="https://www.linkedin.com/in/avinashyadav" target="_blank" aria-label="LinkedIn"><i class="uil uil-linkedin"></i></a>
+    <a href="https://github.com/avinashyadav" target="_blank" aria-label="GitHub"><i class="uil uil-github"></i></a>
   </div>
   <p class="footer__copy">&#169; Avinash Yadav. All rights reserved.</p>
 </footer>
 
 <!-- ==== SCRIPT ==== -->
-<script>
-  // Mobile Menu
-  const navMenu=document.getElementById("nav-menu"),
-        navToggle=document.getElementById("nav-toggle");
-  navToggle.addEventListener("click",()=>navMenu.classList.toggle("show"));
-
-  // Dark Mode Toggle
-  const themeToggle=document.getElementById("theme-toggle");
-  themeToggle.addEventListener("click",()=>{
-    document.body.classList.toggle("dark");
-    document.body.classList.toggle("light");
-  });
-
-  // Scroll Reveal
-  const reveals=document.querySelectorAll(".reveal, section");
-  window.addEventListener("scroll",()=>{
-    reveals.forEach(r=>{
-      if(r.getBoundingClientRect().top < window.innerHeight - 100){
-        r.classList.add("active");
-      }
-    });
-  });
-
-  // Particle Background
-  const canvas=document.getElementById('particle-canvas');
-  const ctx=canvas.getContext('2d');
-  canvas.width=window.innerWidth;
-  canvas.height=window.innerHeight;
-  window.addEventListener('resize',()=>{canvas.width=window.innerWidth; canvas.height=window.innerHeight;});
-  let mouse={x:null,y:null};
-  window.addEventListener('mousemove',(e)=>{mouse.x=e.x; mouse.y=e.y;});
-
-  class Particle{
-    constructor(){
-      this.x=Math.random()*canvas.width;
-      this.y=Math.random()*canvas.height;
-      this.radius=Math.random()*2+1;
-      this.dx=(Math.random()-0.5)*1.5;
-      this.dy=(Math.random()-0.5)*1.5;
-    }
-    draw(){ctx.beginPath(); ctx.arc(this.x,this.y,this.radius,0,Math.PI*2); ctx.fillStyle='rgba(0,119,255,0.7)'; ctx.fill();}
-    update(){
-      if(this.x+this.radius>canvas.width||this.x-this.radius<0) this.dx*=-1;
-      if(this.y+this.radius>canvas.height||this.y-this.radius<0) this.dy*=-1;
-      this.x+=this.dx; this.y+=this.dy; this.draw();
-    }
-  }
-
-  let particlesArray=[];
-  for(let i=0;i<120;i++){particlesArray.push(new Particle());}
-
-  function connectParticles(){
-    for(let a=0;a<particlesArray.length;a++){
-      for(let b=a;b<particlesArray.length;b++){
-        let dx=particlesArray[a].x-particlesArray[b].x;
-        let dy=particlesArray[a].y-particlesArray[b].y;
-        let distance=Math.sqrt(dx*dx+dy*dy);
-        if(distance<100){
-          ctx.beginPath();
-          ctx.strokeStyle='rgba(0,119,255,0.1)';
-          ctx.moveTo(particlesArray[a].x,particlesArray[a].y);
-          ctx.lineTo(particlesArray[b].x,particlesArray[b].y);
-          ctx.stroke();
-        }
-      }
-    }
-  }
-
-  function animate(){
-    ctx.clearRect(0,0,canvas.width,canvas.height);
-    particlesArray.forEach(p=>p.update());
-    connectParticles();
-    requestAnimationFrame(animate);
-  }
-  animate();
-</script>
+<script src="assets/js/home.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the inline styles on the landing page with a polished glassmorphism-inspired layout while keeping all original copy intact
- add a dedicated script to handle theme persistence, responsive navigation, section reveal animations, and a higher fidelity particle background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e4e632588333ba05c127ba09bbae